### PR TITLE
correct url arg passed to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords='django, event, i18n, hvad, multilingual, agenda, planning',
     author='Martin Brochhaus',
     author_email='martin.brochhaus@bitmazk.com',
-    url="https://github.com/bitmazk/django-multilingnual-events",
+    url="https://github.com/bitlabstudio/django-multilingual-events",
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,


### PR DESCRIPTION
It's such a tiny change, please feel free to close this PR and just roll it up into your next release/update of setup.py for bigger reasons...

While only the typo in the project name broke the link from PyPI, this also updates the GitHub accountname while we're at it:

s/bitmazk\/django-multilingnual-events/bitlabstudio\/django-multilingual-events/